### PR TITLE
Harden Monorepo Subtree Operations and Introduce Unit Testing

### DIFF
--- a/docs/dev/git-subtree-creation.md
+++ b/docs/dev/git-subtree-creation.md
@@ -1,0 +1,42 @@
+Detailed overview of the git process for creating an example subtree 'foo-box'.
+For each submodule:
+1. Create github repo with only a single commit (eg. .gitignore or README.md).
+
+2. Create a folder for the submodule inside the monorepo submodules directory.
+
+3. Set up the monorepo for a subtree merge.
+    1. Open "git-bash" console in the local monorepo folder.
+
+    2. Add a new remote URL pointing to the separate submodule repo that was
+    created on step 1.
+    git remote add -f foo-box https://github.com/SophiaSGS/foo-box.git
+    Updating foo-box
+    remote: Enumerating objects: 3, done.
+    remote: Counting objects: 100% (3/3), done.
+    remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
+    Unpacking objects: 100% (3/3), 869 bytes | 8.00 KiB/s, done.
+    From https://github.com/SophiaSGS/foo-box
+    * [new branch]      main       -> foo-box/main
+
+    3. Merge the submodule repo into the monorepo. This doesn't change any of
+    your files locally, but it does prepare Git for the next step.
+    You must also indicate which specific branch you wish to merge. In this
+    case 'main'.
+        git merge -s ours --no-commit --allow-unrelated-histories foo-box/main
+    Automatic merge went well; stopped before committing as requested
+
+    4. Create a folder for the submodule inside the monorepo submodules directory.
+    Then, copy the Git history of the submodule project into it using
+    'read-tree'. '--prefix' is the path inside the monorepo where the module
+    will be stored. You must also specify the branch argument '-u'.
+            "Not a fatal error? false positive."
+        git read-tree --prefix=boxes/foo_box/ -u foo-box/main
+        fatal: refusing to merge unrelated histories
+
+    5. Commit the submodule subtree changes locally.
+    git commit -m "Merged submodule subtree 'foo-box' into monorepo 'boxes/foo_box'."
+    [main fe0ca25] Merged submodule subtree 'foo-box' into monorepo 'boxes/foo_box'.
+
+    6. Push the monorepo's submodule tree changes to the remote GitHub monorepo
+    from the git-bash.
+        git push

--- a/gmash-source/common.sh
+++ b/gmash-source/common.sh
@@ -50,6 +50,11 @@ echo_err(){
   echo -e "\e[31;1mError:\e[0m $*" >&2;
 }
 
+echo_die(){
+  echo_err "$@"
+  exit 1
+}
+
 vecho_err(){
   if [ "$GMASH_VERBOSE" = 1 ]; then
     vecho "\e[31;1m$1\e[0m" "${2:-0}"

--- a/gmash-source/confile.sh
+++ b/gmash-source/confile.sh
@@ -14,6 +14,7 @@
 #   Read: confread <file> <key>
 #@enddoc------------------------------------------------------------------------------------------#
 
+readonly CONFILE_VERSION=1
 
 # Read a key value from a config file.
 # $1 = config file path

--- a/gmash-test/ut-gmash-mono.sh
+++ b/gmash-test/ut-gmash-mono.sh
@@ -1,90 +1,273 @@
 #!/bin/bash
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# CONFIGURATION
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-GMASH_BIN="$SCRIPT_DIR/../gmash"
-TEST_DIR="$(mktemp -u -d "$SCRIPT_DIR/ut-mono-XXXX")"
+# Unit test globals
+GMASH_UNIT_TEST_SEPARATOR="==================================================================
+=================================================================="
+GMASH_BINARY_PATH=""           # Path to gmash binary.
+GMASH_TEST_TEMPDIR=""          # Temp directory for tests.
+GMASH_TEST_SUBREPO_DIR=""      # Test local sub-repo directory.
+GMASH_TEST_MONOREPO_DIR=""     # Test local monorepo directory.
+GMASH_TEST_SUBREPO_BARE=""     # Test bare repo used as remote for the subrepo.
+GMASH_TEST_MONOREPO_BARE=""    # Test bare repo used as remote for the monorepo
+GMASH_TEST_MONO_SUBREPO_PREFIX="" # Subrepo prefix path in the monorepo.
+GMASH_TEST_MONO_SUBREPO_REMOTE="" # Subrepo remote name in the monorepo.
 
-# REPO PREPARATION
-echo ">>> Preparing Test Repositories..."
-SUB_REPO_PATH="$TEST_DIR/origin_sub"
-MONO_REPO_PATH="$TEST_DIR/monorepo"
+configure_testbed(){
+    # Init global paths
+    GMASH_BINARY_PATH="$_SCRIPT_DIR/../gmash" # 'gmash-test' is relative to gmash root
+    GMASH_TEST_TEMPDIR="$(mktemp --tmpdir -d "gmash-unit-tests-XXXX")"
+    GMASH_TEST_SUBREPO_DIR="$GMASH_TEST_TEMPDIR/subrepo"
+    GMASH_TEST_MONOREPO_DIR="$GMASH_TEST_TEMPDIR/monorepo"
+    GMASH_TEST_SUBREPO_BARE="$GMASH_TEST_TEMPDIR/subrepo_remote.git"
+    GMASH_TEST_MONOREPO_BARE="$GMASH_TEST_TEMPDIR/monorepo_remote.git"
+    GMASH_TEST_MONO_SUBREPO_PREFIX="project1"
+    GMASH_TEST_MONO_SUBREPO_REMOTE="project1_origin"
 
-# MONO REMOTE SETUP
-MONO_REMOTE_PATH="$TEST_DIR/mono_remote.git"
-git init --bare "$MONO_REMOTE_PATH"
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+    echo "Configured testbed"
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
 
-# Setup Subrepo
-mkdir -p "$SUB_REPO_PATH"
-git -C "$SUB_REPO_PATH" init -b main
-git -C "$SUB_REPO_PATH" config user.email "test@test.com"
-git -C "$SUB_REPO_PATH" config user.name "Tester"
-echo "Subproject data" > "$SUB_REPO_PATH/sub_data.txt"
-git -C "$SUB_REPO_PATH" add . && git -C "$SUB_REPO_PATH" commit -m "Initial sub"
-git -C "$SUB_REPO_PATH" config receive.denyCurrentBranch ignore
+    echo "  GMASH_BINARY_PATH:        $GMASH_BINARY_PATH"
+    echo "  GMASH_TEST_TEMPDIR:       $GMASH_TEST_TEMPDIR"
+    echo "  GMASH_TEST_SUBREPO_DIR:   $GMASH_TEST_SUBREPO_DIR"
+    echo "  GMASH_TEST_MONOREPO_DIR:  $GMASH_TEST_MONOREPO_DIR"
+    echo "  GMASH_TEST_SUBREPO_BARE:  $GMASH_TEST_SUBREPO_BARE"
+    echo "  GMASH_TEST_MONOREPO_BARE: $GMASH_TEST_MONOREPO_BARE"
 
-# Setup Monorepo
-mkdir -p "$MONO_REPO_PATH"
-git -C "$MONO_REPO_PATH" init -b main
-git -C "$MONO_REPO_PATH" config user.email "test@test.com"
-git -C "$MONO_REPO_PATH" config user.name "Tester"
-git -C "$MONO_REPO_PATH" remote add origin "$TEST_DIR/mono_remote.git"
-git -C "$MONO_REPO_PATH" push -u origin main
-touch "$MONO_REPO_PATH/.gitignore"
-git -C "$MONO_REPO_PATH" add . && git -C "$MONO_REPO_PATH" commit -m "Initial mono"
+    # Switching to test temp dir not to mangle current repo.
+    cd "$GMASH_TEST_TEMPDIR" || exit 1
+}
 
-# TEST CASE 1: SUCCESSFUL ADD
-echo -e "\n\033[34m[TEST 1] Testing successful subtree add...\033[0m"
-cd "$MONO_REPO_PATH"
+cleanup_testbed(){
+    echo "Cleaning up testbed at: $GMASH_TEST_TEMPDIR"
+    rm -rf "$GMASH_TEST_TEMPDIR"
+}
+# Cleanup testbed on any script exit.
+trap cleanup_testbed EXIT INT TERM
 
-# Run with -x for full visibility
-"$GMASH_BIN" -V mono sub -p "libs/sub_project" -r "origin_sub" -l "$SUB_REPO_PATH" -b "main"
-RESULT=$?
+refresh_testbed(){
+    echo "Refreshing testbed at: $GMASH_TEST_TEMPDIR"
+    rm -rf "$GMASH_TEST_TEMPDIR" && mkdir -p "$GMASH_TEST_TEMPDIR"
+}
 
-if [ $RESULT -eq 0 ] && [ -f "libs/sub_project/sub_data.txt" ] && [ -f ".gmash/subtree/origin_sub.conf" ]; then
-    echo -e "\033[32mPASS: Subtree added successfully.\033[0m"
-else
-    echo -e "\033[31mFAIL: Subtree add failed with status $RESULT\033[0m"
-    exit 1
-fi
+configure_test_repo_with_local_remote(){
+    local _local_path="$1"
+    local _remote_path="$2"
+    echo "Configuring test repo: local='$_local_path', remote='$_remote_path'"
 
-# TEST CASE 3: SUCCESSFUL PUSH
-echo -e "\n\033[34m[TEST 3] Testing gmash mono push...\033[0m"
+    # Bare local remote setup
+    mkdir -p "$_remote_path"
+    git -C "$_remote_path" init --bare -b main > /dev/null 2>&1
 
-# 1. Ensure we are in the monorepo and it's clean (from previous tests)
-# If you are still in a conflicted state from TEST 2, we need to abort or reset
-git merge --abort 2>/dev/null || true
-git reset --hard HEAD
+    # Local repo setup
+    mkdir -p "$_local_path"
+    git -C "$_local_path" init -b main > /dev/null 2>&1
+    git -C "$_local_path" config core.autocrlf false
+    echo "Initial data" > "$_local_path/data.txt"
+    git -C "$_local_path" config user.email "test@test.com" # user msut be configured for commits
+    git -C "$_local_path" config user.name "Tester"
+    git -C "$_local_path" add . && git -C "$_local_path" commit -m "Initial commit" > /dev/null 2>&1
+    git -C "$_local_path" remote add origin "$_remote_path"
+    git -C "$_local_path" push -u origin main > /dev/null 2>&1
+}
 
-# 2. Make a change in the monorepo's subtree directory
-echo "Feature from Monorepo" >> "libs/sub_project/sub_data.txt"
-git add .
-git commit -m "feat: adding changes from monorepo"
+ut_gmash_mono_sub(){
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+    echo "[UNIT TEST] gmash_mono_sub"
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
 
-# 3. Push the changes back to the sub-repository
-# Using -l to point back to our local "origin_sub" folder
-echo ">>> Executing mono push..."
-"$GMASH_BIN" -V mono push \
-    -p "libs/sub_project" \
-    -r "origin_sub" \
-    -l "$SUB_REPO_PATH" \
-    -b "main" \
-    -B "main"
+    # Change into monorepo dir.
+    cd "$GMASH_TEST_MONOREPO_DIR" || return 1
 
-RESULT=$?
+    # Run gmash mono sub command.
+    "$GMASH_BINARY_PATH" mono sub -p "$GMASH_TEST_MONO_SUBREPO_PREFIX" -r "$GMASH_TEST_MONO_SUBREPO_REMOTE" -l "$GMASH_TEST_SUBREPO_BARE" -b "main" > /dev/null
 
-# Force the subrepo to update its files to match the push that just arrived
-git -C "$SUB_REPO_PATH" reset --hard HEAD
+    # Return code must be 0.
+    local result_=$?
+    if [ $result_ -ne 0 ]; then
+        echo "gmash mono sub command failed with exit code $result_"
+        return 1
+    fi
 
-# 4. Verification: Check the standalone subrepo for the change
-if [ $RESULT -eq 0 ] && grep -q "Feature from Monorepo" "$SUB_REPO_PATH/sub_data.txt"; then
-    echo -e "\033[32mPASS: Changes pushed successfully to subrepo.\033[0m"
-else
-    echo -e "\033[31mFAIL: Push failed or changes not found in subrepo.\033[0m"
-    # Show what's actually in the subrepo file for debugging
-    echo "Subrepo content:"
-    cat "$SUB_REPO_PATH/sub_data.txt"
-    exit 1
-fi
+    # Verify that the subrepo folder was created in the monorepo.
+    if [ ! -d "$GMASH_TEST_MONO_SUBREPO_PREFIX" ]; then
+        echo "Subrepo directory '$GMASH_TEST_MONO_SUBREPO_PREFIX' was not created in the monorepo."
+        return 1
+    fi
 
-rm -rf "$TEST_DIR"
+    # Verify that the subrepo remote is set correctly.
+    local subrepo_remote
+    subrepo_remote="$(git -C "$GMASH_TEST_MONOREPO_DIR" remote get-url "$GMASH_TEST_MONO_SUBREPO_REMOTE" 2>/dev/null)"
+    if [ -z "$subrepo_remote" ]; then
+        echo "Subrepo remote '$GMASH_TEST_MONO_SUBREPO_REMOTE' was not set correctly."
+        return 1
+    fi
+
+    # Verify that the subrepo remote URL matches the expected local subrepo path.
+    if [ "$subrepo_remote" != "$(cygpath -m "$GMASH_TEST_SUBREPO_BARE")" ]; then # git returns normalized windows path
+        echo "Subrepo remote URL '$subrepo_remote' does not match expected '$(cygpath -m "$GMASH_TEST_SUBREPO_BARE")'."
+        return 1
+    fi
+
+    # Check that metadta file was created .gmash/subtree/project1_origin.conf
+    if [ ! -f "$GMASH_TEST_MONOREPO_DIR/.gmash/subtree/$GMASH_TEST_MONO_SUBREPO_REMOTE.conf" ]; then
+        echo "Metadata file '$GMASH_TEST_MONOREPO_DIR/.gmash/subtree/$GMASH_TEST_MONO_SUBREPO_REMOTE.conf' was not created."
+        return 1
+    fi
+
+    # Ensure metadata file contains correct info.
+    local metadata_file="$GMASH_TEST_MONOREPO_DIR/.gmash/subtree/$GMASH_TEST_MONO_SUBREPO_REMOTE.conf"
+
+    # URL line check.
+    local url_line
+    url_line=$(grep "^url=" "$metadata_file")
+    if [ "$url_line" != "url=$GMASH_TEST_SUBREPO_BARE" ]; then
+        echo "Metadata file URL line '$url_line' does not match expected 'url=$GMASH_TEST_SUBREPO_BARE'."
+        return 1
+    fi
+
+    # Branch line check.
+    local branch_line
+    branch_line=$(grep "^branch=" "$metadata_file")
+    if [ "$branch_line" != "branch=main" ]; then
+        echo "Metadata file branch line '$branch_line' does not match expected 'branch=main'."
+        return 1
+    fi
+
+    # Prefix line check.
+    local prefix_line
+    prefix_line=$(grep "^prefix=" "$metadata_file")
+    if [ "$prefix_line" != "prefix=$GMASH_TEST_MONO_SUBREPO_PREFIX" ]; then
+        echo "Metadata file prefix line '$prefix_line' does not match expected 'prefix=$GMASH_TEST_MONO_SUBREPO_PREFIX'."
+        return 1
+    fi
+
+
+    # Leave monorepo dir.
+    cd .. >/dev/null || return 1
+
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+    echo "[PASSED] gmash_mono_sub"
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+}
+
+ut_gmash_mono_push(){
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+    echo "[UNIT TEST] gmash_mono_push"
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+
+    # Change into monorepo dir.
+    cd "$GMASH_TEST_MONOREPO_DIR" || return 1
+
+    # Make a change in the monorepo's subtree directory
+    echo "Feature from Monorepo" >> "$GMASH_TEST_MONO_SUBREPO_PREFIX/data.txt"
+    git -C "$GMASH_TEST_MONOREPO_DIR" add .
+    git -C "$GMASH_TEST_MONOREPO_DIR" commit -m "feat: adding changes from monorepo"
+
+    # Run gmash mono push command.
+    "$GMASH_BINARY_PATH" mono push \
+        -p "$GMASH_TEST_MONO_SUBREPO_PREFIX" \
+        -r "$GMASH_TEST_MONO_SUBREPO_REMOTE" \
+        -l "$GMASH_TEST_SUBREPO_BARE" \
+        -b "main" \
+        -B "main" > /dev/null 2>&1
+
+    # Return code must be 0.
+    local result_=$?
+    if [ $result_ -ne 0 ]; then
+        echo "gmash mono push command failed with exit code $result_"
+        return 1
+    fi
+
+    # Verify that the changes were pushed to the subrepo.
+    local subrepo_log
+    subrepo_log=$(git -C "$GMASH_TEST_SUBREPO_BARE" log --oneline)
+    if ! echo "$subrepo_log" | grep -q "feat: adding changes from monorepo"; then
+        echo "Changes were not pushed to the subrepo."
+        return 1
+    fi
+
+    # Pull changes from the subrepo remote into local to verify content.
+    git -C "$GMASH_TEST_SUBREPO_DIR" pull "$GMASH_TEST_SUBREPO_BARE" main > /dev/null 2>&1
+
+    # Verify file content in the subrepo.
+    local subrepo_file_content
+    subrepo_file_content=$(cat "$GMASH_TEST_SUBREPO_DIR/data.txt")
+    if ! echo "$subrepo_file_content" | grep -q "Feature from Monorepo"; then
+        echo "File content in the subrepo does not match expected changes."
+        return 1
+    fi
+
+    # Leave monorepo dir.
+    cd .. >/dev/null || return 1
+
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+    echo "[PASSED] gmash_mono_push"
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+}
+
+ut_gmash_mono_push_all_single(){
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+    echo "[UNIT TEST] gmash_mono_push_all_single"
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+
+    # Change into monorepo dir.
+    cd "$GMASH_TEST_MONOREPO_DIR" || return 1
+
+    # Make a change in the monorepo's subtree directory
+    echo "Feature from Monorepo push all" >> "$GMASH_TEST_MONO_SUBREPO_PREFIX/data.txt"
+    git -C "$GMASH_TEST_MONOREPO_DIR" add .
+    git -C "$GMASH_TEST_MONOREPO_DIR" commit -m "gmash mono push all single: adding changes from monorepo"
+
+    # Run gmash mono push command.
+    "$GMASH_BINARY_PATH" mono push --all > /dev/null 2>&1
+
+    # Return code must be 0.
+    local result_=$?
+    if [ $result_ -ne 0 ]; then
+        echo "gmash mono push command failed with exit code $result_"
+        return 1
+    fi
+
+    # Verify that the changes were pushed to the subrepo.
+    local subrepo_log
+    subrepo_log=$(git -C "$GMASH_TEST_SUBREPO_BARE" log --oneline)
+    if ! echo "$subrepo_log" | grep -q "gmash mono push all single: adding changes from monorepo"; then
+        echo "Changes were not pushed to the subrepo."
+        return 1
+    fi
+
+    # Pull changes from the subrepo remote into local to verify content.
+    git -C "$GMASH_TEST_SUBREPO_DIR" pull "$GMASH_TEST_SUBREPO_BARE" main > /dev/null 2>&1
+
+    # Verify file content in the subrepo.
+    local subrepo_file_content
+    subrepo_file_content=$(cat "$GMASH_TEST_SUBREPO_DIR/data.txt")
+    if ! echo "$subrepo_file_content" | grep -q "Feature from Monorepo push all"; then
+        echo "File content in the subrepo does not match expected changes."
+        return 1
+    fi
+
+    # Leave monorepo dir.
+    cd .. >/dev/null || return 1
+
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+    echo "[PASSED] gmash_mono_push_all_single"
+    echo "$GMASH_UNIT_TEST_SEPARATOR"
+}
+
+# Config tests.
+configure_testbed
+
+# Setup test group ut_gmash_mono_1
+configure_test_repo_with_local_remote "$GMASH_TEST_MONOREPO_DIR" "$GMASH_TEST_MONOREPO_BARE"
+configure_test_repo_with_local_remote "$GMASH_TEST_SUBREPO_DIR" "$GMASH_TEST_SUBREPO_BARE"
+
+# Run test group ut_gmash_mono_1
+ut_gmash_mono_sub
+ut_gmash_mono_push
+ut_gmash_mono_push_all_single
+
+# Open for debugging if necessary...
+# explorer.exe "$(cygpath -w "$GMASH_TEST_TEMPDIR")"


### PR DESCRIPTION
This PR hardens `mono sub` and `mono pull` by rewriting the commands for safety and readability, adding end-to-end unit tests, and fully integrating the `mono remove` command. Other mono commands are to follow... **goal currently is to make sure gmash is foolproof enough to use on my other personal project**.

### Key Changes

#### 1. Mono Command Hardening (`mono sub` & `mono remove`)
* Replaced "soft" errors with fatal guards (`echo_die`) to prevent partial states. Added checks for dirty working trees, existing remotes, URL collisions, and `.gitignore` conflicts.
* Subtree configurations in `.gmash/subtree/<remote>.conf` now include versioning, and record ISO timestamp.
* `mono sub --new` now automates remote repository creation via the `gh` CLI.
* Defaulted subtree branch name is now stored in `GMASH_MONO_DEFAULT_BRANCH`.

#### 2. New Feature: `mono remove`
* Added support for subtree removal. Stored metadata for given subtree will also be cleared. (maybe add option to keep metadata in future???)
* Added command parser for `mono remove` & recompiled parsers.
* Added `mono remove` to main script command switch case.

#### 3. Automated Testing
* Introduced `ut-gmash-mono.sh`, a basic unit test suite with automated environment setup and teardown.
* Added tests for:
    * `mono sub`: Verifies prefix creation, metadata accuracy, and remote setup.
    * `mono push`: Validates syncing changes from the monorepo back to sub-repositories.
    * `mono push --all`: Ensures bulk synchronization logic is functional.